### PR TITLE
[Feat] 마이페이지 화면에서 내정보수정 기능 구현(닉네임, 이메일 중복체크까지)

### DIFF
--- a/src/main/java/com/codepresso/codepresso/controller/ViewController.java
+++ b/src/main/java/com/codepresso/codepresso/controller/ViewController.java
@@ -3,7 +3,6 @@ package com.codepresso.codepresso.controller;
 import com.codepresso.codepresso.dto.member.FavoriteListResponse;
 import com.codepresso.codepresso.security.LoginUser;
 import com.codepresso.codepresso.service.member.FavoriteService;
-import com.codepresso.codepresso.service.member.MemberProfileService;
 import lombok.Getter;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -18,11 +17,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ViewController {
 
     @Getter
-    private final MemberProfileService memberProfileService;
     private final FavoriteService favoriteService;
 
-    public ViewController(MemberProfileService memberProfileService, FavoriteService favoriteService) {
-        this.memberProfileService = memberProfileService;
+    public ViewController(FavoriteService favoriteService) {
         this.favoriteService = favoriteService;
     }
 
@@ -68,20 +65,4 @@ public class ViewController {
     }
 
 
-    /**
-     * 프로필 수정 처리
-     */
-//    @PostMapping("/profile-update")
-//    public String updateProfile(@RequestParam Long memberId, ProfileUpdateRequest request, Model model) {
-//        try {
-//            // 프로필 수정 후 수정된 정보를 JSP에 전달
-//            UserDetailResponse updatedMember = memberProfileService.updateProfile(memberId, request);
-//            model.addAttribute("member", updatedMember);
-//            model.addAttribute("success", "프로필이 성공적으로 수정되었습니다.");
-//        } catch (Exception e) {
-//            // 에러 발생 시 에러 메시지를 JSP에 전달
-//            model.addAttribute("error", "프로필 수정 중 오류가 발생했습니다: " + e.getMessage());
-//        }
-//        return "member/mypage";
-//    }
 }

--- a/src/main/webapp/WEB-INF/views/member/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/member/mypage.jsp
@@ -10,10 +10,19 @@
                 <div class="badge">CodePress · 마이페이지</div>
                 <h1>내 정보</h1>
 
+                <c:if test="${not empty success}">
+                    <div class="success-message" style="background: #d4edda; color: #155724; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px;">✅ ${success}</div>
+                </c:if>
+                <c:if test="${not empty error}">
+                    <div class="error-message" style="background: #f8d7da; color: #721c24; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px;">❌ ${error}</div>
+                </c:if>
+
                 <style>
                     .info-list { list-style: none; padding: 0; margin: 16px 0; display: grid; gap: 10px; }
                     .info-item { background: var(--white); border: 1px solid rgba(0,0,0,0.06); border-radius: 12px; padding: 12px 14px; }
                     .info-item b { display: inline-block; width: 120px; }
+                    .edit-mode { display: none; }
+                    .edit-mode input { width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; margin-top: 4px; }
                 </style>
 
                 <!--
@@ -21,19 +30,62 @@
                   추가 정보(이메일/닉네임 등)는 API로 불러오거나, 시큐리티 태그로 principal 확장 정보를 노출하는 방식으로 확장할 수 있어요.
                 -->
                 <ul class="info-list">
-                    <li class="info-item"><b>아이디</b> ${pageContext.request.userPrincipal.name}</li>
-                    <li class="info-item"><b>이름</b> <span id="name">불러오는 중...</span></li>
-                    <li class="info-item"><b>전화번호</b> <span id="phone">불러오는 중...</span></li>
-                    <li class="info-item"><b>이메일</b> <span id="email">불러오는 중...</span></li>
-                    <li class="info-item"><b>닉네임</b> <span id="nickname">불러오는 중...</span></li>
+                    <li class="info-item">
+                        <b>아이디</b> ${pageContext.request.userPrincipal.name}
+                    </li>
+                    <li class="info-item">
+                        <b>이름</b> 
+                        <span id="name-display">불러오는 중...</span>
+                        <div class="edit-mode" id="name-edit">
+                            <input type="text" id="name-input" placeholder="이름을 입력하세요">
+                        </div>
+                    </li>
+                    <li class="info-item">
+                        <b>전화번호</b> 
+                        <span id="phone-display">불러오는 중...</span>
+                        <div class="edit-mode" id="phone-edit">
+                            <input type="text" id="phone-input" placeholder="전화번호를 입력하세요">
+                        </div>
+                    </li>
+                    <li class="info-item">
+                        <b>이메일</b> 
+                        <span id="email-display">불러오는 중...</span>
+                        <div class="edit-mode" id="email-edit">
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <input type="email" id="email-input" placeholder="이메일을 입력하세요" style="flex: 1;">
+                                <button type="button" class="btn btn-ghost" onclick="checkEmailDuplicate()" style="padding: 8px 12px; font-size: 12px;">중복체크</button>
+                            </div>
+                            <div id="email-status" style="font-size: 12px; margin-top: 4px;"></div>
+                        </div>
+                    </li>
+                    <li class="info-item">
+                        <b>닉네임</b> 
+                        <span id="nickname-display">불러오는 중...</span>
+                        <div class="edit-mode" id="nickname-edit">
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <input type="text" id="nickname-input" placeholder="닉네임을 입력하세요" style="flex: 1;">
+                                <button type="button" class="btn btn-ghost" onclick="checkNicknameDuplicate()" style="padding: 8px 12px; font-size: 12px;">중복체크</button>
+                            </div>
+                            <div id="nickname-status" style="font-size: 12px; margin-top: 4px;"></div>
+                        </div>
+                    </li>
                 </ul>
 
                 <div class="cta">
                     <a class="btn btn-primary" href="/branch/list">주문하러 가기</a>
                     <a class="btn btn-ghost" href="/favorites">즐겨찾기</a>
+                    <button class="btn btn-ghost" id="edit-btn" onclick="toggleEditMode()">정보 수정</button>
+                </div>
+
+                <div class="edit-mode" id="edit-controls" style="text-align: center; margin: 20px 0;">
+                    <button class="btn btn-primary" onclick="saveProfile()">저장</button>
+                    <button class="btn btn-ghost" onclick="cancelEdit()">취소</button>
                 </div>
 
                 <script>
+                    let isEditMode = false;
+                    let originalData = {};
+
                     // 필요 시, 본인 정보 API(/api/users/me)를 호출해 닉네임/이메일을 채워 넣습니다.
                     function formatPhone(value){
                         const d = (value||'').replace(/\D/g,'').slice(0,11);
@@ -51,16 +103,231 @@
                         }
                     }
 
+                    // 편집 모드 토글
+                    function toggleEditMode() {
+                        isEditMode = !isEditMode;
+                        
+                        if (isEditMode) {
+                            // 편집 모드로 전환
+                            document.getElementById('edit-btn').style.display = 'none';
+                            document.getElementById('edit-controls').style.display = 'block';
+                            
+                            // 모든 편집 필드 표시
+                            document.querySelectorAll('.edit-mode').forEach(el => {
+                                if (el.id !== 'edit-controls') {
+                                    el.style.display = 'block';
+                                }
+                            });
+                            
+                            // 현재 값들을 입력 필드에 설정
+                            document.getElementById('name-input').value = originalData.name || '';
+                            document.getElementById('phone-input').value = originalData.phone || '';
+                            document.getElementById('email-input').value = originalData.email || '';
+                            document.getElementById('nickname-input').value = originalData.nickname || '';
+                            
+                            // 중복 확인 상태 초기화
+                            document.getElementById('email-status').textContent = '';
+                            document.getElementById('nickname-status').textContent = '';
+                            
+                        } else {
+                            // 보기 모드로 전환
+                            document.getElementById('edit-btn').style.display = 'block';
+                            document.getElementById('edit-controls').style.display = 'none';
+                            
+                            // 모든 편집 필드 숨김
+                            document.querySelectorAll('.edit-mode').forEach(el => {
+                                if (el.id !== 'edit-controls') {
+                                    el.style.display = 'none';
+                                }
+                            });
+                        }
+                    }
+
+                    // 편집 취소
+                    function cancelEdit() {
+                        toggleEditMode();
+                    }
+
+                    // 한글 라벨 변환 (signup.jsp와 동일)
+                    function toKoreanField(f) {
+                        switch(f) {
+                            case 'id': return '아이디';
+                            case 'nickname': return '닉네임';
+                            case 'email': return '이메일';
+                            default: return '아이디';
+                        }
+                    }
+
+                    // 2단계 폴백 방식 중복체크 함수 (signup.jsp와 동일)
+                    async function checkDup(endpoint, value, msgEl, label) {
+                        // 허용되지 않은 endpoint가 오면 기본값 id로 보정
+                        const field = (endpoint === 'id' || endpoint === 'nickname' || endpoint === 'email') ? endpoint : 'id';
+                        // 라벨은 항상 필드에서 도출하여 빈 문자열 문제 방지
+                        const labelText = toKoreanField(field);
+                        if (!value) { 
+                            msgEl.textContent = labelText + '를 입력해주세요.'; 
+                            msgEl.className = 'msg bad'; 
+                            return; 
+                        }
+                        
+                        const q = encodeURIComponent(value);
+                        try {
+                            // 1차 시도: 쿼리 파라미터 방식 (/check?type={field}&value=...)
+                            const url1 = '/api/auth/check?type=' + encodeURIComponent(field) + '&value=' + q;
+                            console.log('[dup-check] try1', field, url1);
+                            let res = await fetch(url1);
+                            
+                            // 2차 시도: RESTful 경로 (/check/{field}?value=...)
+                            if (!res.ok) {
+                                const url2 = '/api/auth/check/' + encodeURIComponent(field) + '?value=' + q;
+                                console.log('[dup-check] try2', field, url2);
+                                res = await fetch(url2);
+                            }
+                            
+                            if (!res.ok) throw new Error('중복체크 실패');
+                            
+                            const data = await res.json();
+                            const lbl = toKoreanField((data && data.field) ? data.field : field);
+                            if (data.duplicate) {
+                                msgEl.textContent = '이미 사용 중인 ' + lbl + '입니다.';
+                                msgEl.className = 'msg bad';
+                            } else {
+                                msgEl.textContent = '사용 가능한 ' + lbl + '입니다.';
+                                msgEl.className = 'msg ok';
+                            }
+                        } catch(e) {
+                            msgEl.textContent = '요청 중 오류가 발생했습니다.';
+                            msgEl.className = 'msg bad';
+                        }
+                    }
+
+                    // 이메일 중복 확인
+                    function checkEmailDuplicate() {
+                        const email = document.getElementById('email-input').value;
+                        const statusDiv = document.getElementById('email-status');
+                        
+                        if (!email) {
+                            alert('이메일을 입력해주세요.');
+                            return;
+                        }
+
+                        // 현재 이메일과 같으면 중복 확인하지 않음
+                        if (email === originalData.email) {
+                            statusDiv.textContent = '현재 사용 중인 이메일입니다.';
+                            statusDiv.style.color = '#666';
+                            return;
+                        }
+
+                        checkDup('email', email, statusDiv, '이메일');
+                    }
+
+                    // 닉네임 중복 확인
+                    function checkNicknameDuplicate() {
+                        const nickname = document.getElementById('nickname-input').value;
+                        const statusDiv = document.getElementById('nickname-status');
+                        
+                        if (!nickname) {
+                            alert('닉네임을 입력해주세요.');
+                            return;
+                        }
+
+                        // 현재 닉네임과 같으면 중복 확인하지 않음
+                        if (nickname === originalData.nickname) {
+                            statusDiv.textContent = '현재 사용 중인 닉네임입니다.';
+                            statusDiv.style.color = '#666';
+                            return;
+                        }
+
+                        checkDup('nickname', nickname, statusDiv, '닉네임');
+                    }
+
+
+
+                    // 프로필 저장
+                    function saveProfile() {
+                        const email = document.getElementById('email-input').value;
+                        const nickname = document.getElementById('nickname-input').value;
+                        const emailStatus = document.getElementById('email-status').textContent;
+                        const nicknameStatus = document.getElementById('nickname-status').textContent;
+
+                        // 이메일이 변경되었는데 중복 확인을 하지 않은 경우
+                        if (email && email !== originalData.email && !emailStatus.includes('사용 가능') && !emailStatus.includes('현재 사용 중')) {
+                            alert('이메일 중복체크를 해주세요.');
+                            return;
+                        }
+
+                        // 닉네임이 변경되었는데 중복 확인을 하지 않은 경우
+                        if (nickname && nickname !== originalData.nickname && !nicknameStatus.includes('사용 가능') && !nicknameStatus.includes('현재 사용 중')) {
+                            alert('닉네임 중복체크를 해주세요.');
+                            return;
+                        }
+
+                        // 중복된 값으로는 저장 불가
+                        if (email && email !== originalData.email && emailStatus.includes('이미 사용 중')) {
+                            alert('이메일이 중복됩니다. 다른 이메일을 입력해주세요.');
+                            return;
+                        }
+
+                        if (nickname && nickname !== originalData.nickname && nicknameStatus.includes('이미 사용 중')) {
+                            alert('닉네임이 중복됩니다. 다른 닉네임을 입력해주세요.');
+                            return;
+                        }
+
+                        const requestData = {
+                            name: document.getElementById('name-input').value,
+                            phone: document.getElementById('phone-input').value,
+                            email: email,
+                            nickname: nickname
+                        };
+
+                        fetch('/api/users/me', {
+                            method: 'PUT',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify(requestData)
+                        })
+                        .then(response => {
+                            if (response.ok) {
+                                // 성공 시 페이지 새로고침
+                                location.reload();
+                            } else {
+                                alert('프로필 수정에 실패했습니다.');
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Error:', error);
+                            alert('프로필 수정 중 오류가 발생했습니다.');
+                        });
+                    }
+
+                    // 페이지 로드 시 사용자 정보 가져오기
                     (async function(){
                         try {
                             const res = await fetch('/api/users/me');
-                            if (!res.ok) return; // 미로그인 등
+                            if (!res.ok) {
+                                if (res.status === 401) {
+                                    alert('로그인이 필요합니다. 로그인 페이지로 이동합니다.');
+                                    window.location.href = '/auth/login';
+                                    return;
+                                }
+                                return; // 기타 오류
+                            }
                             const data = await res.json();
-                            if (data.name) document.getElementById('name').textContent = data.name;
-                            if (data.phone) document.getElementById('phone').textContent = formatPhone(data.phone);
-                            if (data.email) document.getElementById('email').textContent = data.email;
-                            if (data.nickname) document.getElementById('nickname').textContent = data.nickname;
-                        } catch (e) { /* 무시 */ }
+                            
+                            // 원본 데이터 저장
+                            originalData = data;
+                            
+                            // 화면에 표시
+                            if (data.name) document.getElementById('name-display').textContent = data.name;
+                            if (data.phone) document.getElementById('phone-display').textContent = formatPhone(data.phone);
+                            if (data.email) document.getElementById('email-display').textContent = data.email;
+                            if (data.nickname) document.getElementById('nickname-display').textContent = data.nickname;
+                        } catch (e) { 
+                            console.error('사용자 정보 로드 오류:', e);
+                            alert('사용자 정보를 불러올 수 없습니다. 로그인 페이지로 이동합니다.');
+                            window.location.href = '/auth/login';
+                        }
                     })();
                 </script>
             </div>


### PR DESCRIPTION
마이페이지 화면에 '내정보수정' 버튼을 만들어서 그 버튼을 클릭하면 아이디를 제외한 다른 정보들을 수정할 수 있게 만들었습니다.
이메일과 닉네임 같은 경우는 수정하기 전에 중복체크를 해서 기존에 없을 때만 수정할 수 있게 하였습니다.

즐겨찾기 추가, 수정, 삭제 api도 정상적으로 동작하는 것을 확인했습니다.